### PR TITLE
Updated servo horn attachment

### DIFF
--- a/_posts/2014-11-21-building-the-reference-bot.md
+++ b/_posts/2014-11-21-building-the-reference-bot.md
@@ -31,7 +31,9 @@ You want to get a feel for where everything will go.  Lay your major components 
 ![Rough-out the parts](/assets/nodebot-assemble/nodebot-rough-out.JPG)
 
 ### Attach your wheels to your servos
-The easiest way to do this is to remove the servo horn and attach the horn to the wheels using the self-drilling screws.  The holes in the servo horn are smaller than the screws but these things make quick work of the plastic and go right through to the wood.  Just make sure they are centered. Reattach the horns when you are done.
+Attach a servo horn (from those provided with the servo) to each of the wheels using the self-drilling screws.  The holes in the servo horn are smaller than the screws but these screws make quick work of the plastic and go right through to the wood (just make sure the servo horn is centered on your wheel). 
+
+Once the horns are attached to the wheels, attach each wheel to a servo using the small black screws provided.
 
 ![Attach the wheels to the servo horns](/assets/nodebot-assemble/nodebot-attach-wheels-to-servo.JPG)
 


### PR DESCRIPTION
See Trello:
- https://trello.com/c/J61AePhP/69-website-instructions-for-reference-kit-don-t-specify-to-make-sure-wheels-are-screwed-to-the-servos
- https://trello.com/c/zqiBP4Kb/68-website-servos-are-not-attached-to-the-horns-when-out-of-the-bag-so-description-to-detach-is-confusing
